### PR TITLE
Update to Kibana v4.1.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && apt-get -y upgrade
 RUN apt-get -y install wget nginx-full apache2-utils supervisor
 
 WORKDIR /opt
-RUN wget --no-check-certificate -O- https://download.elasticsearch.org/kibana/kibana/kibana-4.0.1-linux-x64.tar.gz | tar xvfz -
+RUN wget --no-check-certificate -O- https://download.elastic.co/kibana/kibana/kibana-4.1.1-linux-x64.tar.gz | tar xvfz - 
 RUN mkdir /etc/kibana # This is where the htpasswd file is placed by the run script
 
 ADD kibana /etc/nginx/sites-available/kibana

--- a/run
+++ b/run
@@ -1,5 +1,5 @@
 #!/bin/bash
-sed -i "s/localhost:9200/es:9200/g" /opt/kibana-4.0.1-linux-x64/config/kibana.yml
+sed -i "s/localhost:9200/es:9200/g" /opt/kibana-4.1.1-linux-x64/config/kibana.yml
 if [ "$KIBANA_SECURE" = "true" ] ; then
 	ln -s /etc/nginx/sites-available/kibana-secure /etc/nginx/sites-enabled/kibana
 	htpasswd -bc /etc/kibana/htpasswd ${KIBANA_USER} ${KIBANA_PASSWORD}

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -2,7 +2,7 @@
 nodaemon=true
 
 [program:kibana]
-command=/opt/kibana-4.0.1-linux-x64/bin/kibana
+command=/opt/kibana-4.1.1-linux-x64/bin/kibana
 autorestart=true
 
 [program:nginx]


### PR DESCRIPTION
Change download link:
* to get the latest version (Kibana v4.1.1.)
* update the donwload link from download.elasticsearch.org to download.elastic.co